### PR TITLE
Adds a check that makes sure you can't name a variable input

### DIFF
--- a/src/main/scala/pipedsl/common/Errors.scala
+++ b/src/main/scala/pipedsl/common/Errors.scala
@@ -198,5 +198,9 @@ object Errors {
     withPos(s"Not enough constraints provided to infer types. Found error at $e", e.pos)
   )
 
+  case class ExtremelyCriticalExceptionFailure(msg :String, pos:Position) extends RuntimeException(
+    withPos(s"Extremely Critical Exception Failure at: $msg", pos)
+  )
+
   case class IntWidthNotSpecified() extends RuntimeException
 }

--- a/src/main/scala/pipedsl/common/Syntax.scala
+++ b/src/main/scala/pipedsl/common/Syntax.scala
@@ -439,6 +439,10 @@ object Syntax {
   case class EApp(func: Id, args: List[Expr]) extends Expr
   case class ECall(mod: Id, method: Option[Id] = None, args: List[Expr]) extends Expr
   case class EVar(id: Id) extends Expr
+  {
+    if(id.v == "input")
+      throw ExtremelyCriticalExceptionFailure("Do not under any circumstances even THINK about naming a variable input", id.pos)
+  }
   case class ECast(ctyp: Type, exp: Expr) extends Expr
   {
     typ = Some(ctyp)

--- a/src/test/tests/autocastTests/autocast-basic-pass.pdl
+++ b/src/test/tests/autocastTests/autocast-basic-pass.pdl
@@ -27,11 +27,11 @@ def ass_cast_test() :int<32>
     return c;
   }
 
-def tern_cast_test(input :bool) :int<32>
+def tern_cast_test(inpt :bool) :int<32>
   {
     a = 10<10>;
     b = 1<30>;
-    d = ((input) ? (a) : (b));
+    d = ((inpt) ? (a) : (b));
     return d;
   }
 
@@ -66,18 +66,18 @@ pipe output_cast()[] :int<32>
 
 
 
-pipe recv_cast1(input :uint<32>)[rf :int<32>[32]<a,a>(Queue)]
+pipe recv_cast1(inpt :uint<32>)[rf :int<32>[32]<a,a>(Queue)]
   {
     start(rf);
-    reserve(rf[input], W);
+    reserve(rf[inpt], W);
     end(rf);
     ---
     int<10> a = 4;
-    block(rf[input]);
-    rf[input] <- a;
+    block(rf[inpt]);
+    rf[inpt] <- a;
     ---
-    release(rf[input]);
-    call recv_cast1(input);
+    release(rf[inpt]);
+    call recv_cast1(inpt);
   }
 
 pipe recv_cast2()[]
@@ -87,18 +87,18 @@ pipe recv_cast2()[]
   }
 
 
-pipe test1(input: int<32>)[rf: int<32>[32]] {
-  a = input;
+pipe test1(inpt: int<32>)[rf: int<32>[32]] {
+  a = inpt;
   b = true;
   c = b;
   if (c) {
     d = a + 5<32>;  
   }
-  call test1(input);
+  call test1(inpt);
 }
 
-pipe test2(input: int<32>)[rf: int<32>[32]] {
-  a = input;
+pipe test2(inpt: int<32>)[rf: int<32>[32]] {
+  a = inpt;
   b = true;
   c = b;
   if (c) {
@@ -106,7 +106,7 @@ pipe test2(input: int<32>)[rf: int<32>[32]] {
   } else {
     d = b;
   }
-  call test2(input);
+  call test2(inpt);
 }
 
 pipe test3()[] {
@@ -157,8 +157,8 @@ pipe test5()[] {
 }
 
 
-pipe test6(input: int<32>)[rf: int<32>[32]] {
-  a = input;
+pipe test6(inpt: int<32>)[rf: int<32>[32]] {
+  a = inpt;
   b = true;
   c = b;
   if (c) {
@@ -166,7 +166,7 @@ pipe test6(input: int<32>)[rf: int<32>[32]] {
   } else {
     d = b;
   }
-  call test6(input);
+  call test6(inpt);
 }
 
 pipe test7()[rf: uint<32>[32]<a,a>(Queue)] {

--- a/src/test/tests/autocastTests/type-inference-basic-pass.pdl
+++ b/src/test/tests/autocastTests/type-inference-basic-pass.pdl
@@ -13,18 +13,18 @@ def helper2(a:bool, b: bool): bool {
   return c;
 }
 
-pipe test1(input: int<32>)[rf: int<32>[32]] {
-  a = input;
+pipe test1(inpt: int<32>)[rf: int<32>[32]] {
+  a = inpt;
   b = true;
   c = b;
   if (c) {
     d = a + 5<32>;  
   }
-  call test1(input);
+  call test1(inpt);
 }
 
-pipe test2(input: int<32>)[rf: int<32>[32]] {
-  a = input;
+pipe test2(inpt: int<32>)[rf: int<32>[32]] {
+  a = inpt;
   b = true;
   c = b;
   if (c) {
@@ -32,7 +32,7 @@ pipe test2(input: int<32>)[rf: int<32>[32]] {
   } else {
     d = b;
   }
-  call test2(input);
+  call test2(inpt);
 }
 
 pipe test3()[] {
@@ -83,8 +83,8 @@ pipe test5()[] {
 }
 
 
-pipe test6(input: int<32>)[rf: int<32>[32]] {
-  a = input;
+pipe test6(inpt: int<32>)[rf: int<32>[32]] {
+  a = inpt;
   b = true;
   c = b;
   if (c) {
@@ -92,7 +92,7 @@ pipe test6(input: int<32>)[rf: int<32>[32]] {
   } else {
     d = b;
   }
-  call test6(input);
+  call test6(inpt);
 }
 
 pipe test7()[rf: uint<32>[32]<a,a>(Queue)] {

--- a/src/test/tests/autocastTests/type-inference-bit-width-tests.pdl
+++ b/src/test/tests/autocastTests/type-inference-bit-width-tests.pdl
@@ -12,14 +12,14 @@ def helper2(a:bool, b: bool): bool {
   return c;
 }
 
-pipe test1(input: int<32>)[rf: int<32>[32]] {
+pipe test1(inpt: int<32>)[rf: int<32>[32]] {
   a = 6 * 6<10>;
   int<32> b = a;
   int<32> c = a + b;
   call test1(c);
 }
 
-pipe test2(input: int<32>)[rf: int<32>[32]<a,a>(Queue)] {
+pipe test2(inpt: int<32>)[rf: int<32>[32]<a,a>(Queue)] {
   a = 1;
   start(rf);
   reserve(rf[a]);
@@ -32,14 +32,14 @@ pipe test2(input: int<32>)[rf: int<32>[32]<a,a>(Queue)] {
   call test2(b);
 }
 
-pipe test3(input: int<32>)[rf: int<32>[32]] {
+pipe test3(inpt: int<32>)[rf: int<32>[32]] {
   a = 1<32>;
   int<32> b = a << 4;
   c = a << 4;
   call test3(c);
 }
 
-pipe test4(input: int<32>)[rf: int<32>[32]] {
+pipe test4(inpt: int<32>)[rf: int<32>[32]] {
   a = 15<32>;
   int<32> b = cast(a{0:8}, int<32>);
   call test4(a);

--- a/src/test/tests/autocastTests/type-inference-fail-base-type.pdl
+++ b/src/test/tests/autocastTests/type-inference-fail-base-type.pdl
@@ -1,5 +1,5 @@
-pipe test1(input: int<32>)[rf: int<32>[32]] {
-  a = input + 2<32>;
+pipe test1(inpt: int<32>)[rf: int<32>[32]] {
+  a = inpt + 2<32>;
   if (a) {
     
   }

--- a/src/test/tests/autocastTests/type-inference-fail-boolBinOp.pdl
+++ b/src/test/tests/autocastTests/type-inference-fail-boolBinOp.pdl
@@ -1,6 +1,6 @@
 
-pipe test1(input: int<32>)[rf: int<32>[32]] {
-  a = input;
+pipe test1(inpt: int<32>)[rf: int<32>[32]] {
+  a = inpt;
   b = a || a;
 }
 

--- a/src/test/tests/autocastTests/type-inference-fail-eqBinOp.pdl
+++ b/src/test/tests/autocastTests/type-inference-fail-eqBinOp.pdl
@@ -1,6 +1,6 @@
-pipe test1(input: int<32>)[rf: int<32>[32]] {
+pipe test1(inpt: int<32>)[rf: int<32>[32]] {
   a = true;
-  b = a == input;
+  b = a == inpt;
 }
 
 circuit {

--- a/src/test/tests/autocastTests/type-inference-fail-func-app-arg.pdl
+++ b/src/test/tests/autocastTests/type-inference-fail-func-app-arg.pdl
@@ -2,7 +2,7 @@ def func(a: bool, b: int<32>): bool {
   return b;
 }
 
-pipe test1(input: int<32>)[rf: int<32>[32]] {
+pipe test1(inpt: int<32>)[rf: int<32>[32]] {
   a = true;
   b = func(a, a);
 }

--- a/src/test/tests/autocastTests/type-inference-fail-funcApp.pdl
+++ b/src/test/tests/autocastTests/type-inference-fail-funcApp.pdl
@@ -2,9 +2,9 @@ def func(a: bool, b: int<32>): bool {
   return b;
 }
 
-pipe test1(input: int<32>)[rf: int<32>[32]] {
+pipe test1(inpt: int<32>)[rf: int<32>[32]] {
   a = true;
-  b = func(a, input) + 5<32>;
+  b = func(a, inpt) + 5<32>;
 }
 
 circuit {

--- a/src/test/tests/autocastTests/type-inference-fail-numBinOp.pdl
+++ b/src/test/tests/autocastTests/type-inference-fail-numBinOp.pdl
@@ -1,4 +1,4 @@
-pipe test1(input: int<32>)[rf: int<32>[32]] {
+pipe test1(inpt: int<32>)[rf: int<32>[32]] {
   a = true;
   b = a + a;
 }

--- a/src/test/tests/autocastTests/type-inference-fail-ternary.pdl
+++ b/src/test/tests/autocastTests/type-inference-fail-ternary.pdl
@@ -1,6 +1,6 @@
-pipe test1(input: int<32>)[rf: int<32>[32]] {
+pipe test1(inpt: int<32>)[rf: int<32>[32]] {
   a = true;
-  b = input;
+  b = inpt;
   c = (b) ? a : b;
 }
 

--- a/src/test/tests/registerRenamingTests/lock-wrong-type-nested-fail.pdl
+++ b/src/test/tests/registerRenamingTests/lock-wrong-type-nested-fail.pdl
@@ -1,6 +1,6 @@
-pipe test3(input: uint<32>)[rf: int<32>[5]<c,s>] {
-    uint<5> rs1 = input{0:4};
-    uint<5> rs2 = input{5:9};
+pipe test3(inpt: uint<32>)[rf: int<32>[5]<c,s>] {
+    uint<5> rs1 = inpt{0:4};
+    uint<5> rs2 = inpt{5:9};
     start(rf);
     acquire(rf[rs2], W);
     end(rf);

--- a/src/test/tests/registerRenamingTests/lock-wrong-type-read-write-fail.pdl
+++ b/src/test/tests/registerRenamingTests/lock-wrong-type-read-write-fail.pdl
@@ -1,6 +1,6 @@
-pipe test3(input: uint<32>)[rf: int<32>[5]] {
-    uint<5> rs1 = input{0:4};
-    uint<5> rs2 = input{5:9};
+pipe test3(inpt: uint<32>)[rf: int<32>[5]] {
+    uint<5> rs1 = inpt{0:4};
+    uint<5> rs2 = inpt{5:9};
     start(rf);
     acquire(rf[rs2], R);
     end(rf);

--- a/src/test/tests/registerRenamingTests/lock-wrong-type-write-read-fail.pdl
+++ b/src/test/tests/registerRenamingTests/lock-wrong-type-write-read-fail.pdl
@@ -1,6 +1,6 @@
-pipe test3(input: uint<32>)[rf: int<32>[5]] {
-    uint<5> rs1 = input{0:4};
-    uint<5> rs2 = input{5:9};
+pipe test3(inpt: uint<32>)[rf: int<32>[5]] {
+    uint<5> rs1 = inpt{0:4};
+    uint<5> rs2 = inpt{5:9};
     start(rf);
     acquire(rf[rs2], W);
     end(rf);

--- a/src/test/tests/typecheckTests/acquire-in-expr-fail.pdl
+++ b/src/test/tests/typecheckTests/acquire-in-expr-fail.pdl
@@ -1,14 +1,14 @@
 //Expected Fail
-pipe test6(input: int<32>)[rf: int<32>[5]<c,s>] {
+pipe test6(inpt: int<32>)[rf: int<32>[5]<c,s>] {
     start(rf);
     reserve(rf);
     end(rf);
     ---
-    int<32> x = rf[u0<5>] + input;
+    int<32> x = rf[u0<5>] + inpt;
     ---
     block(rf);
     release(rf);
-    call test6(input);
+    call test6(inpt);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/acquire-in-expr.pdl
+++ b/src/test/tests/typecheckTests/acquire-in-expr.pdl
@@ -1,14 +1,14 @@
 //Expected Success
-pipe test6(input: int<32>)[rf: int<32>[5]<c,s>(Queue)] {
+pipe test6(inpt: int<32>)[rf: int<32>[5]<c,s>(Queue)] {
     start(rf);
     reserve(rf);
     end(rf);
     ---
     block(rf);
-    int<32> x = rf[u0<5>] + input;
+    int<32> x = rf[u0<5>] + inpt;
     ---
     release(rf);
-    call test6(input);
+    call test6(inpt);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/boolean-mishap.pdl
+++ b/src/test/tests/typecheckTests/boolean-mishap.pdl
@@ -1,24 +1,24 @@
-pipe mistake(input: int<32>)[rf: int<32>[5]<c, s>] {
-   bool a = input{0:0};
-   bool b = input{1:1};
+pipe mistake(inpt: int<32>)[rf: int<32>[5]<c, s>] {
+   bool a = inpt{0:0};
+   bool b = inpt{1:1};
    if(a && b)
      {
-       call mistake(input);
+       call mistake(inpt);
      }
    ---
    if(a && !b)
      {
-       call mistake(input);
+       call mistake(inpt);
      }
    ---
    if((!a) && b)
      {
-       call mistake(input);
+       call mistake(inpt);
      }
    ---
    if(!(a && b))
      {
-       call mistake(input);
+       call mistake(inpt);
      }
 }
 

--- a/src/test/tests/typecheckTests/double-call-fail.pdl
+++ b/src/test/tests/typecheckTests/double-call-fail.pdl
@@ -1,14 +1,14 @@
 //cannot call twice in same pipe
-pipe call2(input: int<32>)[rf: int<32>[5]<c,s>] {
+pipe call2(inpt: int<32>)[rf: int<32>[5]<c,s>] {
     start(rf);
     reserve(rf);
     end(rf);
     ---
     block(rf);
-    int<32> x = rf[0<5>] + input;
+    int<32> x = rf[0<5>] + inpt;
     call call2(x);
     ---
-    int<32> y = rf[0<5>] + input;
+    int<32> y = rf[0<5>] + inpt;
     call call2(y);
     ---
     release(rf);

--- a/src/test/tests/typecheckTests/double-call-guarded.pdl
+++ b/src/test/tests/typecheckTests/double-call-guarded.pdl
@@ -1,11 +1,11 @@
-pipe call_guard(input: int<32>)[rf: int<32>[5]<c, s>(Queue)] {
+pipe call_guard(inpt: int<32>)[rf: int<32>[5]<c, s>(Queue)] {
     start(rf);
     reserve(rf);
     end(rf);
     ---
     block(rf);
-    int<32> x = rf[u0<5>] + input;
-    int<1> bit = input{0:0};
+    int<32> x = rf[u0<5>] + inpt;
+    int<1> bit = inpt{0:0};
     if (bit == 1) {
         call call_guard(x);
     }

--- a/src/test/tests/typecheckTests/input-smt-fail.pdl
+++ b/src/test/tests/typecheckTests/input-smt-fail.pdl
@@ -1,13 +1,13 @@
-pipe should_fail(input : int<32>)[]
+pipe should_fail(inpt : int<32>)[]
 {
-  if(input{1:1} == 1)
+  if(inpt{1:1} == 1)
   {
-     call should_fail(input);
+     call should_fail(inpt);
   }
   ---
-  if(input{2:2} == 1)
+  if(inpt{2:2} == 1)
   {
-    call should_fail(input);
+    call should_fail(inpt);
   }
 }
 

--- a/src/test/tests/typecheckTests/lock-acquire-in-split-case.pdl
+++ b/src/test/tests/typecheckTests/lock-acquire-in-split-case.pdl
@@ -1,4 +1,4 @@
-pipe test22(input: uint<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]<c,s>(Queue)] {
+pipe test22(inpt: uint<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]<c,s>(Queue)] {
     start(rf);
     split {
         case: randomBool {
@@ -7,7 +7,7 @@ pipe test22(input: uint<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]
         case: randomBool2 {
             reserve(rf);
         }
-        case: (input{0:0} == u1) {
+        case: (inpt{0:0} == u1) {
             reserve(rf);
         }
         default: {
@@ -17,10 +17,10 @@ pipe test22(input: uint<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]
     end(rf);
     ---
     block(rf);
-    int<32> x <- rf[input{4:0}];
+    int<32> x <- rf[inpt{4:0}];
     release(rf);
     ---
-    call test22(input, randomBool, randomBool2);
+    call test22(inpt, randomBool, randomBool2);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/lock-fail-acquire-before-access.pdl
+++ b/src/test/tests/typecheckTests/lock-fail-acquire-before-access.pdl
@@ -1,15 +1,15 @@
 
-pipe test6(input: uint<32>)[rf: int<32>[5]] {
+pipe test6(inpt: uint<32>)[rf: int<32>[5]] {
     start(rf);
-    if (input{0:0} == u1) {
-        int<32> arg <- rf[input{31:27}];
+    if (inpt{0:0} == u1) {
+        int<32> arg <- rf[inpt{31:27}];
         release(rf);
     } else {
-        int<32> arg <- rf[input{31:27}];
+        int<32> arg <- rf[inpt{31:27}];
         release(rf);
     }
     end(rf);
-    call test6(input);
+    call test6(inpt);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/lock-fail-branch-acquire.pdl
+++ b/src/test/tests/typecheckTests/lock-fail-branch-acquire.pdl
@@ -1,11 +1,11 @@
-pipe test1(input: int<32>)[rf: int<32>[5]] {
+pipe test1(inpt: int<32>)[rf: int<32>[5]] {
     start(rf);
-    if (input{0:0} == 1) {
+    if (inpt{0:0} == 1) {
         acquire(rf);
     }
     release(rf);
     end(rf);
-    call test1(input);
+    call test1(inpt);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/lock-fail-branch-release.pdl
+++ b/src/test/tests/typecheckTests/lock-fail-branch-release.pdl
@@ -1,8 +1,8 @@
-pipe test3(input: int<32>)[rf: int<32>[5]] {
+pipe test3(inpt: int<32>)[rf: int<32>[5]] {
     start(rf);
     acquire(rf);
-    if (input{0:0} == 1) {
-        int<32> arg <- rf[cast(input{4:0}, uint<5>)];
+    if (inpt{0:0} == 1) {
+        int<32> arg <- rf[cast(inpt{4:0}, uint<5>)];
         release(rf);
     }
     end(rf);

--- a/src/test/tests/typecheckTests/lock-fail-double-write.pdl
+++ b/src/test/tests/typecheckTests/lock-fail-double-write.pdl
@@ -1,6 +1,6 @@
-pipe test3(input: uint<32>)[rf: int<32>[5], m:int<32>[5]] {
-    uint<5> rs1 = input{0:4};
-    uint<5> rs2 = input{5:9};
+pipe test3(inpt: uint<32>)[rf: int<32>[5], m:int<32>[5]] {
+    uint<5> rs1 = inpt{0:4};
+    uint<5> rs2 = inpt{5:9};
     start(rf);
     start(m);
     acquire(rf[rs1],R);
@@ -14,7 +14,7 @@ pipe test3(input: uint<32>)[rf: int<32>[5], m:int<32>[5]] {
     release(rf[rs1]);
     release(rf[rs2]);
     release(m[rs1]);
-    call test3(input);
+    call test3(inpt);
 }
 
 

--- a/src/test/tests/typecheckTests/lock-fail-no-acquire-before-release.pdl
+++ b/src/test/tests/typecheckTests/lock-fail-no-acquire-before-release.pdl
@@ -1,13 +1,13 @@
 
-pipe test7(input: int<32>)[rf: int<32>[5]] {
+pipe test7(inpt: int<32>)[rf: int<32>[5]] {
     start(rf);
-    if (input{0:0} == 1) {
+    if (inpt{0:0} == 1) {
         release(rf);
     } else {
         release(rf);
     }
     end(rf);
-    call test7(input);
+    call test7(inpt);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/lock-fail-no-acquire-in-split-case.pdl
+++ b/src/test/tests/typecheckTests/lock-fail-no-acquire-in-split-case.pdl
@@ -1,4 +1,4 @@
-pipe test22(input: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]] {
+pipe test22(inpt: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]] {
     start(rf);
     split {
         case: randomBool {
@@ -7,7 +7,7 @@ pipe test22(input: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]]
         case: randomBool2 {
             int<32> c <- rf[u0<5>];
         }
-        case: (input{0:0} == 1) {
+        case: (inpt{0:0} == 1) {
             acquire(rf);
         }
         default: {
@@ -16,7 +16,7 @@ pipe test22(input: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]]
     }
     release(rf);
     end(rf);
-    call test22(input, randomBool, randomBool2);
+    call test22(inpt, randomBool, randomBool2);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/lock-fail-no-default-acquire-split.pdl
+++ b/src/test/tests/typecheckTests/lock-fail-no-default-acquire-split.pdl
@@ -1,4 +1,4 @@
-pipe test21(input: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]] {
+pipe test21(inpt: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]] {
     start(rf);
     split {
         case: randomBool {
@@ -7,13 +7,13 @@ pipe test21(input: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]]
         case: randomBool2 {
             acquire(rf);
         }
-        case: (input{0:0} == 1) {
+        case: (inpt{0:0} == 1) {
             acquire(rf);
         }
     }
     release(rf);
     end(rf);
-    call test21(input, randomBool, randomBool2);
+    call test21(inpt, randomBool, randomBool2);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/lock-fail-read-after-writes-branch.pdl
+++ b/src/test/tests/typecheckTests/lock-fail-read-after-writes-branch.pdl
@@ -1,21 +1,21 @@
 //Expected Fail
-pipe test3(input: uint<32>)[rf: int<32>[5]] {
-    uint<5> rs1 = input{0:4};
-    uint<5> rs2 = input{5:9};
+pipe test3(inpt: uint<32>)[rf: int<32>[5]] {
+    uint<5> rs1 = inpt{0:4};
+    uint<5> rs2 = inpt{5:9};
     start(rf);
     acquire(rf[rs1],R);
     acquire(rf[rs2],W);
     end(rf);
     ---
     release(rf[rs2]);
-    if (input{0:0} == u1) {
+    if (inpt{0:0} == u1) {
         int<32> arg1 <- rf[rs1];
         release(rf[rs1]);
     } else {
         int<32> arg1 <- rf[rs1];
         release(rf[rs1]);
     }
-    call test3(input);
+    call test3(inpt);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/lock-fail-read-after-writes-release.pdl
+++ b/src/test/tests/typecheckTests/lock-fail-read-after-writes-release.pdl
@@ -1,21 +1,21 @@
 //Expected Fail
-pipe test3(input: uint<32>)[rf: int<32>[5]] {
-    uint<5> rs1 = input{0:4};
-    uint<5> rs2 = input{5:9};
+pipe test3(inpt: uint<32>)[rf: int<32>[5]] {
+    uint<5> rs1 = inpt{0:4};
+    uint<5> rs2 = inpt{5:9};
     start(rf);
     acquire(rf[rs1],R);
     acquire(rf[rs2],W);
     end(rf);
     ---
     release(rf[rs2]);
-    if (input{0:0} == u1) {
+    if (inpt{0:0} == u1) {
         int<32> arg1 <- rf[rs1];
         release(rf[rs1]);
     } else {
         int<32> arg1 <- rf[rs1];
         release(rf[rs1]);
     }
-    call test3(input);
+    call test3(inpt);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/lock-fail-reads-after-writes.pdl
+++ b/src/test/tests/typecheckTests/lock-fail-reads-after-writes.pdl
@@ -1,12 +1,12 @@
 //Expected Fail
-pipe test3(input: uint<32>)[rf: int<32>[5]] {
-    uint<5> rs1 = input{0:4};
-    uint<5> rs2 = input{5:9};
+pipe test3(inpt: uint<32>)[rf: int<32>[5]] {
+    uint<5> rs1 = inpt{0:4};
+    uint<5> rs2 = inpt{5:9};
     start(rf);
     acquire(rf[rs2],W);
     acquire(rf[rs1],R);
     end(rf);
-    if (input{0:0} == u1) {
+    if (inpt{0:0} == u1) {
         int<32> arg1 <- rf[rs1];
         release(rf[rs1]);
     } else {
@@ -14,7 +14,7 @@ pipe test3(input: uint<32>)[rf: int<32>[5]] {
         release(rf[rs1]);
     }
     release(rf[rs2]);
-    call test3(input);
+    call test3(inpt);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/lock-fail-reserve-without-write.pdl
+++ b/src/test/tests/typecheckTests/lock-fail-reserve-without-write.pdl
@@ -1,7 +1,7 @@
 //Expected Success
-pipe test3(input: uint<32>)[rf: int<32>[5], m:int<32>[5]] {
-    uint<5> rs1 = input{0:4};
-    uint<5> rs2 = input{5:9};
+pipe test3(inpt: uint<32>)[rf: int<32>[5], m:int<32>[5]] {
+    uint<5> rs1 = inpt{0:4};
+    uint<5> rs2 = inpt{5:9};
     start(rf);
     start(m);
     acquire(rf[rs1],R);
@@ -14,13 +14,13 @@ pipe test3(input: uint<32>)[rf: int<32>[5], m:int<32>[5]] {
     release(rf[rs1]);
     release(rf[rs2]);
     release(m[rs1]);
-    call test3(input);
+    call test3(inpt);
 }
 
 //Tests that modules are analyzed separately
-pipe test4(input: uint<32>)[rf: int<32>[5], m:int<32>[5]] :bool {
-    uint<5> rs1 = input{0:4};
-    uint<5> rs2 = input{5:9};
+pipe test4(inpt: uint<32>)[rf: int<32>[5], m:int<32>[5]] :bool {
+    uint<5> rs1 = inpt{0:4};
+    uint<5> rs2 = inpt{5:9};
     start(rf);
     start(m);
     acquire(rf[rs1],R);
@@ -32,7 +32,7 @@ pipe test4(input: uint<32>)[rf: int<32>[5], m:int<32>[5]] :bool {
     release(rf[rs1]);
     release(rf[rs2]);
     release(m[rs1]);
-    call test3(input);
+    call test3(inpt);
     output(true);
 }
 

--- a/src/test/tests/typecheckTests/lock-fail-top-branch.pdl
+++ b/src/test/tests/typecheckTests/lock-fail-top-branch.pdl
@@ -1,5 +1,5 @@
 
-pipe test16(input: int<32>)[rf: int<32>[5]] {
+pipe test16(inpt: int<32>)[rf: int<32>[5]] {
     int<32> y = 3<32>;
     int<32> x = 0<32>;
     start(rf);
@@ -11,7 +11,7 @@ pipe test16(input: int<32>)[rf: int<32>[5]] {
     }
     release(rf);
     end(rf);
-    call test16(input);
+    call test16(inpt);
 }
 circuit {
     r = memory(int<32>, 5);

--- a/src/test/tests/typecheckTests/lock-fail-wrong-branch-acquire.pdl
+++ b/src/test/tests/typecheckTests/lock-fail-wrong-branch-acquire.pdl
@@ -1,4 +1,4 @@
-pipe test18(input: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]] {
+pipe test18(inpt: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]] {
     bool a = true;
     bool b = false;
     start(rf);
@@ -14,7 +14,7 @@ pipe test18(input: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]]
         }
     }
     end(rf);
-    call test18(input, randomBool2, randomBool);
+    call test18(inpt, randomBool2, randomBool);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/lock-release-OOO-different-address-fail.pdl
+++ b/src/test/tests/typecheckTests/lock-release-OOO-different-address-fail.pdl
@@ -1,8 +1,8 @@
 //Expected Fail
-pipe test3(input: uint<32>)[rf: int<32>[5]] {
-    uint<5> rs1 = input{0:4};
-    uint<5> rs2 = input{5:9};
-    bool a = input{0:0} == u1;
+pipe test3(inpt: uint<32>)[rf: int<32>[5]] {
+    uint<5> rs1 = inpt{0:4};
+    uint<5> rs2 = inpt{5:9};
+    bool a = inpt{0:0} == u1;
     start(rf);
     acquire(rf[rs1],W);
     acquire(rf[rs2],W);
@@ -19,7 +19,7 @@ pipe test3(input: uint<32>)[rf: int<32>[5]] {
     if (!a) {
         release(rf[rs2]);
     }
-    call test3(input);
+    call test3(inpt);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/lock-release-OOO-fail.pdl
+++ b/src/test/tests/typecheckTests/lock-release-OOO-fail.pdl
@@ -1,19 +1,19 @@
 //Expected Fail
-pipe test3(input: uint<32>)[rf: int<32>[5]] {
-    uint<5> rs1 = input{0:4};
-    uint<5> rs2 = input{5:9};
+pipe test3(inpt: uint<32>)[rf: int<32>[5]] {
+    uint<5> rs1 = inpt{0:4};
+    uint<5> rs2 = inpt{5:9};
     start(rf);
     acquire(rf[rs1],W);
     acquire(rf[rs2],R);
     end(rf);
-    if (input{0:0} == u1) {
+    if (inpt{0:0} == u1) {
         release(rf[rs1]);
         release(rf[rs2]);
     } else {
         release(rf[rs1]);
         release(rf[rs2]);
     }
-    call test3(input);
+    call test3(inpt);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/lock-release-OOO-nested-branches-fail.pdl
+++ b/src/test/tests/typecheckTests/lock-release-OOO-nested-branches-fail.pdl
@@ -1,7 +1,7 @@
 //Expected Fail
-pipe test3(input: uint<32>)[rf: int<32>[5]] {
-    uint<5> rs1 = input{0:4};
-    uint<5> rs2 = input{5:9};
+pipe test3(inpt: uint<32>)[rf: int<32>[5]] {
+    uint<5> rs1 = inpt{0:4};
+    uint<5> rs2 = inpt{5:9};
     bool a = rs1 == rs2;
     bool b = rs1 + u5<5> == rs2 + u5<5>;
     bool c = rs1 + u6<5> == rs2 + u6<5>;
@@ -39,7 +39,7 @@ pipe test3(input: uint<32>)[rf: int<32>[5]] {
         }
     }
     release(rf[rs1]);
-    call test3(input);
+    call test3(inpt);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/lock-release-OOO-nested-if-fail.pdl
+++ b/src/test/tests/typecheckTests/lock-release-OOO-nested-if-fail.pdl
@@ -1,7 +1,7 @@
 //Expected Fail
-pipe test3(input: uint<32>)[rf: int<32>[5]] {
-    uint<5> rs1 = input{0:4};
-    uint<5> rs2 = input{5:9};
+pipe test3(inpt: uint<32>)[rf: int<32>[5]] {
+    uint<5> rs1 = inpt{0:4};
+    uint<5> rs2 = inpt{5:9};
     bool a = rs1 == rs2;
     bool b = rs1 + u5<5> == rs2 + u5<5>;
     start(rf);
@@ -19,7 +19,7 @@ pipe test3(input: uint<32>)[rf: int<32>[5]] {
     if(a && !b) {
         release(rf[rs1]);
     }
-    call test3(input);
+    call test3(inpt);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/lock-release-OOO-split-fail.pdl
+++ b/src/test/tests/typecheckTests/lock-release-OOO-split-fail.pdl
@@ -1,16 +1,16 @@
 //Expected Fail
-pipe test3(input: uint<32>)[rf: int<32>[5]] {
-    uint<5> rs1 = input{0:4};
-    uint<5> rs2 = input{5:9};
+pipe test3(inpt: uint<32>)[rf: int<32>[5]] {
+    uint<5> rs1 = inpt{0:4};
+    uint<5> rs2 = inpt{5:9};
     start(rf);
     acquire(rf[rs1],W);
     acquire(rf[rs2],W);
     end(rf);
     split {
-        case: (input{0:0} == u0) {
+        case: (inpt{0:0} == u0) {
             release(rf[rs2]);
         }
-        case: ( input{0:0} == u1) {
+        case: ( inpt{0:0} == u1) {
             release(rf[rs2]);
         }
         default: {

--- a/src/test/tests/typecheckTests/lock-success-read-write-order.pdl
+++ b/src/test/tests/typecheckTests/lock-success-read-write-order.pdl
@@ -1,7 +1,7 @@
 //Expected Success
-pipe test3(input: uint<32>)[rf: int<32>[5]<c2,s>(RenameRF), m:int<32>[5]<c2,s>(RenameRF)] {
-    uint<5> rs1 = input{0:4};
-    uint<5> rs2 = input{5:9};
+pipe test3(inpt: uint<32>)[rf: int<32>[5]<c2,s>(RenameRF), m:int<32>[5]<c2,s>(RenameRF)] {
+    uint<5> rs1 = inpt{0:4};
+    uint<5> rs2 = inpt{5:9};
     start(rf);
     start(m);
     reserve(rf[rs1],R);
@@ -19,13 +19,13 @@ pipe test3(input: uint<32>)[rf: int<32>[5]<c2,s>(RenameRF), m:int<32>[5]<c2,s>(R
     release(rf[rs1]);
     release(rf[rs2]);
     release(m[rs1]);
-    call test3(input);
+    call test3(inpt);
 }
 
 //Tests that modules are analyzed separately
-pipe test4(input: uint<32>)[rf: int<32>[5]<c2,s>(RenameRF), m:int<32>[5]<c2,s>(RenameRF)] :bool {
-    uint<5> rs1 = input{0:4};
-    uint<5> rs2 = input{5:9};
+pipe test4(inpt: uint<32>)[rf: int<32>[5]<c2,s>(RenameRF), m:int<32>[5]<c2,s>(RenameRF)] :bool {
+    uint<5> rs1 = inpt{0:4};
+    uint<5> rs2 = inpt{5:9};
     start(rf);
     start(m);
     acquire(rf[rs1],R);

--- a/src/test/tests/typecheckTests/lock-tests-general.pdl
+++ b/src/test/tests/typecheckTests/lock-tests-general.pdl
@@ -1,23 +1,23 @@
 // Expected Success
-pipe test2(input: int<32>)[rf: int<32>[5]<c2,s>(Queue)] {
+pipe test2(inpt: int<32>)[rf: int<32>[5]<c2,s>(Queue)] {
     start(rf);
-    if (input{0:0} == 1) {
+    if (inpt{0:0} == 1) {
         reserve(rf);
 	---
 	block(rf);
         release(rf);
     }
     end(rf);
-    call test2(input);
+    call test2(inpt);
 }
 //Expected Success
-pipe test4(input: int<32>)[rf: int<32>[5]<c2,s>(Queue)] {
+pipe test4(inpt: int<32>)[rf: int<32>[5]<c2,s>(Queue)] {
     start(rf);
-    if (input{0:0} == 1) {
+    if (inpt{0:0} == 1) {
 	reserve(rf);
 	---
 	block(rf);
-        int<32> arg <- rf[cast(input{4:0}, uint<5>)];
+        int<32> arg <- rf[cast(inpt{4:0}, uint<5>)];
         release(rf);
     } else {
         ---
@@ -28,28 +28,28 @@ pipe test4(input: int<32>)[rf: int<32>[5]<c2,s>(Queue)] {
         release(rf);
     }
     end(rf);
-    call test4(input);
+    call test4(inpt);
 }
 //Expected Success
-pipe test5(input: int<32>)[rf: int<32>[5]<c2,s>(Queue)] {
+pipe test5(inpt: int<32>)[rf: int<32>[5]<c2,s>(Queue)] {
 
     start(rf);
     reserve(rf);
     ---
     block(rf);
-    if (input{0:0} == 1) {        
+    if (inpt{0:0} == 1) {        
         release(rf);
     } else {
-        int<32> arg <- rf[cast(input{31:27}, uint<5>)];
+        int<32> arg <- rf[cast(inpt{31:27}, uint<5>)];
         release(rf);
     }
     end(rf);
-    call test5(input);
+    call test5(inpt);
 }
 //Expected success since reserve is before branch
-pipe test8(input: int<32>)[rf: int<32>[5]<a,a>(Queue)] {
+pipe test8(inpt: int<32>)[rf: int<32>[5]<a,a>(Queue)] {
     start(rf);
-    if (input{0:0} == 1) {
+    if (inpt{0:0} == 1) {
         ---
         reserve(rf);
 	---
@@ -62,7 +62,7 @@ pipe test8(input: int<32>)[rf: int<32>[5]<a,a>(Queue)] {
 	block(rf);
         int<32> out <- rf[u1<5>];
     }
-    call test8(input);
+    call test8(inpt);
     ---
     rf[u2<5>] <- out;
     release(rf);
@@ -70,10 +70,10 @@ pipe test8(input: int<32>)[rf: int<32>[5]<a,a>(Queue)] {
     ---
 }
 //Expected success
-pipe test9(input: int<32>)[rf: int<32>[5]<c2,s>(Queue), dmem: int<32>[32]<a,a>(Queue)] {
+pipe test9(inpt: int<32>)[rf: int<32>[5]<c2,s>(Queue), dmem: int<32>[32]<a,a>(Queue)] {
     start(dmem);
     start(rf);
-    if (input{0:0} == 1) {
+    if (inpt{0:0} == 1) {
         reserve(rf);
 	---
 	block(rf);
@@ -85,10 +85,10 @@ pipe test9(input: int<32>)[rf: int<32>[5]<c2,s>(Queue), dmem: int<32>[32]<a,a>(Q
     block(dmem);
     release(dmem);
     end(dmem);
-    call test9(input);
+    call test9(inpt);
 }
 //Expected Success
-pipe test15(input: int<32>)[rf: int<32>[5]<c2,s>(Queue)] {
+pipe test15(inpt: int<32>)[rf: int<32>[5]<c2,s>(Queue)] {
     bool a = true;
     start(rf);
     if (a) {
@@ -100,11 +100,11 @@ pipe test15(input: int<32>)[rf: int<32>[5]<c2,s>(Queue)] {
         release(rf);
     }
     end(rf);
-    call test15(input);
+    call test15(inpt);
 }
 
 //Expected Success
-pipe test17(input: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]<c2,s>(Queue)] {
+pipe test17(inpt: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]<c2,s>(Queue)] {
     bool a = true;
     bool b = false;
     start(rf);
@@ -121,12 +121,12 @@ pipe test17(input: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]<
         }
     }
     end(rf);
-    call test17(input, randomBool2, randomBool);
+    call test17(inpt, randomBool2, randomBool);
 }
 
 
 //ExpectedSuccess
-pipe test19(input: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]<c2,s>(Queue)] {
+pipe test19(inpt: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]<c2,s>(Queue)] {
     start(rf);
     split {
         case: randomBool {
@@ -136,7 +136,7 @@ pipe test19(input: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]<
             reserve(rf);
 
         }
-        case: (input{0:0} == 1) {
+        case: (inpt{0:0} == 1) {
             reserve(rf);
         }
         default: {
@@ -147,11 +147,11 @@ pipe test19(input: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]<
     block(rf);
     release(rf);
     end(rf);
-    call test19(input, randomBool2, randomBool);
+    call test19(inpt, randomBool2, randomBool);
 }
 
 //ExpectedSuccess
-pipe test20(input: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]<c2,s>(Queue)] {
+pipe test20(inpt: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]<c2,s>(Queue)] {
     start(rf);
     split {
         case: randomBool {
@@ -166,7 +166,7 @@ pipe test20(input: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]<
 	    block(rf);
             release(rf);	    
         }
-        case: (input{0:0} == 1) {
+        case: (inpt{0:0} == 1) {
             reserve(rf);
 	    ---
 	    block(rf);
@@ -180,7 +180,7 @@ pipe test20(input: int<32>, randomBool: bool, randomBool2: bool)[rf: int<32>[5]<
         }
     }
     end(rf);
-    call test20(input, randomBool2, randomBool);
+    call test20(inpt, randomBool2, randomBool);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/lock-tests-specific.pdl
+++ b/src/test/tests/typecheckTests/lock-tests-specific.pdl
@@ -1,21 +1,21 @@
 //Expected Success
-pipe test1(input: uint<32>)[rf: int<32>[5]<c2, s>(Queue)] {
-    uint<5> rs1 = input{0:4};
-    uint<5> rs2 = input{5:9};
+pipe test1(inpt: uint<32>)[rf: int<32>[5]<c2, s>(Queue)] {
+    uint<5> rs1 = inpt{0:4};
+    uint<5> rs2 = inpt{5:9};
     start(rf);
     int<32> arg1 <- rf<a>[rs1]; 
     int<32> arg2 <- rf<a>[rs2]; 
     end(rf);
     ---
-    call test1(input);
+    call test1(inpt);
 } 
 
 //Expected Success
-pipe test2(input: uint<32>)[rf: int<32>[5]<c2, s>(Queue)] {
-    uint<5> rs1 = input{0:4};
-    uint<5> rs2 = input{5:9};
+pipe test2(inpt: uint<32>)[rf: int<32>[5]<c2, s>(Queue)] {
+    uint<5> rs1 = inpt{0:4};
+    uint<5> rs2 = inpt{5:9};
     start(rf);
-    bool doR1 = (input{0:0} == u1);
+    bool doR1 = (inpt{0:0} == u1);
     if (doR1) {
         reserve(rf[rs1],R);
     }
@@ -30,17 +30,17 @@ pipe test2(input: uint<32>)[rf: int<32>[5]<c2, s>(Queue)] {
     block(rf[rs2]);
     int<32> arg2 <- rf[rs2];
     release(rf[rs2]);
-    call test2(input);
+    call test2(inpt);
     ---
 }
 
 
 //Expected Success
-pipe test5(input: uint<32>, randomBool: bool, randomBool2: bool)[rf:int<32>[5]<c2, s>(Queue)] {
+pipe test5(inpt: uint<32>, randomBool: bool, randomBool2: bool)[rf:int<32>[5]<c2, s>(Queue)] {
     bool a = true;
     bool b = false;
-    uint<5> rs1 = input{0:4};
-    uint<5> rs2 = input{5:9};
+    uint<5> rs1 = inpt{0:4};
+    uint<5> rs2 = inpt{5:9};
     start(rf);
     reserve(rf[rs2],R);
     if (randomBool == a) {
@@ -60,7 +60,7 @@ pipe test5(input: uint<32>, randomBool: bool, randomBool2: bool)[rf:int<32>[5]<c
     block(rf[rs2]);
     y = rf[rs2];
     release(rf[rs2]);
-    call test5(input, randomBool2, randomBool);
+    call test5(inpt, randomBool2, randomBool);
 }
 circuit {
     r = memory(int<32>, 5);

--- a/src/test/tests/typecheckTests/lock-wellformedness-fail.pdl
+++ b/src/test/tests/typecheckTests/lock-wellformedness-fail.pdl
@@ -1,20 +1,20 @@
-pipe test1(input: uint<32>)[rf: int<32>[5]] {
-    uint<5> rs2 = input{13:9};
-    if (input{0:0} == u1) {
+pipe test1(inpt: uint<32>)[rf: int<32>[5]] {
+    uint<5> rs2 = inpt{13:9};
+    if (inpt{0:0} == u1) {
         reserve(rf[rs2]);
         acquire(rf[rs2]);
         release(rf[rs2]);
     }
-    call test1(input);
+    call test1(inpt);
 }
 
-pipe test2(input: uint<32>)[rf: int<32>[5]] {
-    if (input{0:0} == u1) {
+pipe test2(inpt: uint<32>)[rf: int<32>[5]] {
+    if (inpt{0:0} == u1) {
         reserve(rf);
         acquire(rf);
         release(rf);
     }
-    call test2(input);
+    call test2(inpt);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/missing-one-fail.pdl
+++ b/src/test/tests/typecheckTests/missing-one-fail.pdl
@@ -1,8 +1,8 @@
-pipe quad_call(input: int<32>)[rf: int<32>[5]<c, s>]
+pipe quad_call(inpt: int<32>)[rf: int<32>[5]<c, s>]
   {
-    bool a = input{0:0};
-    bool b = input{1:1};
-    bool c = input{2:2};
+    bool a = inpt{0:0};
+    bool b = inpt{1:1};
+    bool c = inpt{2:2};
     if(a && b && c)
       {
         output(true);

--- a/src/test/tests/typecheckTests/quad-call-disjoint.pdl
+++ b/src/test/tests/typecheckTests/quad-call-disjoint.pdl
@@ -1,49 +1,49 @@
-pipe quad_call(input: uint<32>)[rf: int<32>[5]<c, s>] {
-   bool a = input{0:0};
-   bool b = input{1:1};
+pipe quad_call(inpt: uint<32>)[rf: int<32>[5]<c, s>] {
+   bool a = inpt{0:0};
+   bool b = inpt{1:1};
    if(a && b)
      {
-       call quad_call(input);
+       call quad_call(inpt);
      }
    ---
    if(a && !b)
      {
-       call quad_call(input);
+       call quad_call(inpt);
      }
    ---
    if((!a) && b)
      {
-       call quad_call(input);
+       call quad_call(inpt);
      }
    ---
    if((!a) && (!b))
      {
-       call quad_call(input);
+       call quad_call(inpt);
      }
 }
 
-pipe comparison(input: int<32>, bool1: bool, bool2: bool)[rf: int<32>[5]<c, s>]
+pipe comparison(inpt: int<32>, bool1: bool, bool2: bool)[rf: int<32>[5]<c, s>]
 {
-  int<16> a = input{0:15};
-  int<16> b = input{16:31};
+  int<16> a = inpt{0:15};
+  int<16> b = inpt{16:31};
   bool lt = a < b;
   bool eq = a == b;
   split {
     case: bool1
       {
-        call comparison(input, bool2, bool1);
+        call comparison(inpt, bool2, bool1);
       }
     case: bool2
       {
-        call comparison(input + 1<32>, bool1, bool2);
+        call comparison(inpt + 1<32>, bool1, bool2);
       }
-    case: (input{0:0} == 1)
+    case: (inpt{0:0} == 1)
       {
-        call comparison(input - 1<32>, bool2, bool1);
+        call comparison(inpt - 1<32>, bool2, bool1);
       }
     default:
       {
-        call comparison(input, bool1, bool2);
+        call comparison(inpt, bool1, bool2);
       }
   }
 }
@@ -54,14 +54,14 @@ pipe getFalse()[] :bool
 }
 
 //at least it is smart about else lol
-pipe test1(input: int<32>)[rf: int<32>[5]]
+pipe test1(inpt: int<32>)[rf: int<32>[5]]
   {
-    if(input{0:0} == 1)
+    if(inpt{0:0} == 1)
       {
-        call test1(input);
+        call test1(inpt);
       } else
       {
-        call test1(input);
+        call test1(inpt);
       }
       ---
       

--- a/src/test/tests/typecheckTests/signedInts.pdl
+++ b/src/test/tests/typecheckTests/signedInts.pdl
@@ -1,6 +1,6 @@
 //Expected Success
-pipe signtest(input: int<8>)[]: bool {
-    int<8> x = input + 1<8>;
+pipe signtest(inpt: int<8>)[]: bool {
+    int<8> x = inpt + 1<8>;
     bool a = x > -1<8>;
     print(a);
     bool b = cast(x, uint<8>) > cast(-1<8>, uint<8>);

--- a/src/test/tests/typecheckTests/type-inference-basic-pass.pdl
+++ b/src/test/tests/typecheckTests/type-inference-basic-pass.pdl
@@ -13,18 +13,18 @@ def helper2(a:bool, b: bool): bool {
   return c;
 }
 
-pipe test1(input: int<32>)[rf: int<32>[32]] {
-  a = input;
+pipe test1(inpt: int<32>)[rf: int<32>[32]] {
+  a = inpt;
   b = true;
   c = b;
   if (c) {
     d = a + 5<32>;  
   }
-  call test1(input);
+  call test1(inpt);
 }
 
-pipe test2(input: int<32>)[rf: int<32>[32]] {
-  a = input;
+pipe test2(inpt: int<32>)[rf: int<32>[32]] {
+  a = inpt;
   b = true;
   c = b;
   if (c) {
@@ -32,7 +32,7 @@ pipe test2(input: int<32>)[rf: int<32>[32]] {
   } else {
     d = b;
   }
-  call test2(input);
+  call test2(inpt);
 }
 
 pipe test3()[] {
@@ -83,8 +83,8 @@ pipe test5()[] {
 }
 
 
-pipe test6(input: int<32>)[rf: int<32>[32]] {
-  a = input;
+pipe test6(inpt: int<32>)[rf: int<32>[32]] {
+  a = inpt;
   b = true;
   c = b;
   if (c) {
@@ -92,7 +92,7 @@ pipe test6(input: int<32>)[rf: int<32>[32]] {
   } else {
     d = b;
   }
-  call test6(input);
+  call test6(inpt);
 }
 
 pipe test7()[rf: uint<32>[32]<a,a>] {

--- a/src/test/tests/typecheckTests/type-inference-bit-width-tests.pdl
+++ b/src/test/tests/typecheckTests/type-inference-bit-width-tests.pdl
@@ -12,14 +12,14 @@ def helper2(a:bool, b: bool): bool {
   return c;
 }
 
-pipe test1(input: int<32>)[rf: int<32>[32]] {
+pipe test1(inpt: int<32>)[rf: int<32>[32]] {
   a = 6 * 6<5>;
   int<32> b = a;
   int<32> c = a + b;
   call test1(c);
 }
 
-pipe test2(input: int<32>)[rf: int<32>[32]<a,a>(Queue)] {
+pipe test2(inpt: int<32>)[rf: int<32>[32]<a,a>(Queue)] {
   a = 1;
   start(rf);
   b <- rf<a>[a];
@@ -28,14 +28,14 @@ pipe test2(input: int<32>)[rf: int<32>[32]<a,a>(Queue)] {
   call test2(b);
 }
 
-pipe test3(input: int<32>)[rf: int<32>[32]] {
+pipe test3(inpt: int<32>)[rf: int<32>[32]] {
   a = 1<32>;
   int<32> b = a << 4;
   c = a << 4;
   call test3(c);
 }
 
-pipe test4(input: int<32>)[rf: int<32>[32]] {
+pipe test4(inpt: int<32>)[rf: int<32>[32]] {
   a = 15<32>;
   int<32> b = cast(a{0:8}, int<32>);
   call test4(a);

--- a/src/test/tests/typecheckTests/type-inference-fail-base-type.pdl
+++ b/src/test/tests/typecheckTests/type-inference-fail-base-type.pdl
@@ -1,5 +1,5 @@
-pipe test1(input: int<32>)[rf: int<32>[32]] {
-  a = input + 2<32>;
+pipe test1(inpt: int<32>)[rf: int<32>[32]] {
+  a = inpt + 2<32>;
   if (a) {
     
   }

--- a/src/test/tests/typecheckTests/type-inference-fail-boolBinOp.pdl
+++ b/src/test/tests/typecheckTests/type-inference-fail-boolBinOp.pdl
@@ -1,6 +1,6 @@
 
-pipe test1(input: int<32>)[rf: int<32>[32]] {
-  a = input;
+pipe test1(inpt: int<32>)[rf: int<32>[32]] {
+  a = inpt;
   b = a || a;
 }
 

--- a/src/test/tests/typecheckTests/type-inference-fail-eqBinOp.pdl
+++ b/src/test/tests/typecheckTests/type-inference-fail-eqBinOp.pdl
@@ -1,6 +1,6 @@
-pipe test1(input: int<32>)[rf: int<32>[32]] {
+pipe test1(inpt: int<32>)[rf: int<32>[32]] {
   a = true;
-  b = a == input;
+  b = a == inpt;
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/type-inference-fail-func-app-arg.pdl
+++ b/src/test/tests/typecheckTests/type-inference-fail-func-app-arg.pdl
@@ -2,7 +2,7 @@ def func(a: bool, b: int<32>): bool {
   return b;
 }
 
-pipe test1(input: int<32>)[rf: int<32>[32]] {
+pipe test1(inpt: int<32>)[rf: int<32>[32]] {
   a = true;
   b = func(a, a);
 }

--- a/src/test/tests/typecheckTests/type-inference-fail-funcApp.pdl
+++ b/src/test/tests/typecheckTests/type-inference-fail-funcApp.pdl
@@ -2,9 +2,9 @@ def func(a: bool, b: int<32>): bool {
   return b;
 }
 
-pipe test1(input: int<32>)[rf: int<32>[32]] {
+pipe test1(inpt: int<32>)[rf: int<32>[32]] {
   a = true;
-  b = func(a, input) + 5<32>;
+  b = func(a, inpt) + 5<32>;
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/type-inference-fail-numBinOp.pdl
+++ b/src/test/tests/typecheckTests/type-inference-fail-numBinOp.pdl
@@ -1,4 +1,4 @@
-pipe test1(input: int<32>)[rf: int<32>[32]] {
+pipe test1(inpt: int<32>)[rf: int<32>[32]] {
   a = true;
   b = a + a;
 }

--- a/src/test/tests/typecheckTests/type-inference-fail-ternary.pdl
+++ b/src/test/tests/typecheckTests/type-inference-fail-ternary.pdl
@@ -1,6 +1,6 @@
-pipe test1(input: int<32>)[rf: int<32>[32]] {
+pipe test1(inpt: int<32>)[rf: int<32>[32]] {
   a = true;
-  b = input;
+  b = inpt;
   c = (b) ? a : b;
 }
 

--- a/src/test/tests/typecheckTests/unlocked-mem-1.pdl
+++ b/src/test/tests/typecheckTests/unlocked-mem-1.pdl
@@ -1,14 +1,14 @@
 //Expected Success
-pipe unlock(input: int<32>)[rf: int<32>[5]<c,s>] {
+pipe unlock(inpt: int<32>)[rf: int<32>[5]<c,s>] {
     spec_check();
-    s <- speccall unlock(input + 1<32>);
+    s <- speccall unlock(inpt + 1<32>);
     ---
     start(rf);
-    int<32> x = rf[u0<5>] + input;
+    int<32> x = rf[u0<5>] + inpt;
     end(rf);
     ---
     spec_barrier();
-    verify(s, input);
+    verify(s, inpt);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/unlocked-mem-fail-1.pdl
+++ b/src/test/tests/typecheckTests/unlocked-mem-fail-1.pdl
@@ -1,11 +1,11 @@
 //Expected Success
-pipe unlock(input: int<32>)[rf: int<32>[5]<c,s>] {
+pipe unlock(inpt: int<32>)[rf: int<32>[5]<c,s>] {
     start(rf);
-    int<32> x = rf[u0<5>] + input;
+    int<32> x = rf[u0<5>] + inpt;
     end(rf);
     ---
     rf[u1<5>] <- x;    
-    call unlock(input);
+    call unlock(inpt);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/unlocked-mem-fail.pdl
+++ b/src/test/tests/typecheckTests/unlocked-mem-fail.pdl
@@ -1,15 +1,15 @@
 //Expected Fail
-pipe unlock(input: int<32>)[rf: int<32>[5]<c,s>] {
+pipe unlock(inpt: int<32>)[rf: int<32>[5]<c,s>] {
     spec_check();
-    s <- speccall unlock(input + 1<32>);
+    s <- speccall unlock(inpt + 1<32>);
     ---
     start(rf);
-    int<32> x = rf[u0<5>] + input;
+    int<32> x = rf[u0<5>] + inpt;
     rf[u1<5>] <- x; //no speculative write
     end(rf);
     ---
     spec_barrier();
-    verify(s, input);
+    verify(s, inpt);
 }
 
 circuit {

--- a/src/test/tests/typecheckTests/unlocked-mem.pdl
+++ b/src/test/tests/typecheckTests/unlocked-mem.pdl
@@ -1,11 +1,11 @@
 //Expected Success
-pipe unlock(input: int<32>)[rf: int<32>[5]<c,s>] {
+pipe unlock(inpt: int<32>)[rf: int<32>[5]<c,s>] {
     start(rf);
-    int<32> x = rf[u0<5>] + input;
+    int<32> x = rf[u0<5>] + inpt;
     rf[u1<5>] <- x;
     end(rf);
     ---
-    call unlock(input);
+    call unlock(inpt);
 }
 
 circuit {


### PR DESCRIPTION
after spending approx 30 minutes hunting down a bug because of this, i want this change lol. I think this is relevant to one of the github issues about bluespec keywords, but i haven't fixed it, just added a check for the word input since i am very very tempted to name the argument of a single arg test function input (and so are you, as there were a couple instances of this in the tests :))