### PR TITLE
Outputqueue

### DIFF
--- a/bscRuntime/memories/Makefile
+++ b/bscRuntime/memories/Makefile
@@ -5,7 +5,7 @@ B_LIB=$(BMOD).bo
 B_SIM=tb.bsv
 OUT=Top
 
-TOBUILD=Ehr.bo Locks.bo Memories.bo Speculation.bo
+TOBUILD=Ehr.bo Locks.bo Memories.bo Speculation.bo SpecialQueues.bo
 
 ## Default simulator is iverilog
 VSIM = -vsim iverilog

--- a/bscRuntime/memories/SpecialQueues.bsv
+++ b/bscRuntime/memories/SpecialQueues.bsv
@@ -1,6 +1,7 @@
 package SpecialQueues;
 
 import Ehr :: *;
+import ConfigReg :: *;
 import FIFOF :: *;
 
 export OutputQ(..);
@@ -21,22 +22,22 @@ module mkOutputFIFOF(ttyp initT, OutputQ#(ttyp, dtyp) res) provisos
    (Bits#(ttyp, szttyp),Bits#(dtyp, szdtyp), Arith#(ttyp), Eq#(ttyp));
 
    Ehr#(2, ttyp) nextTag <- mkEhr(initT);
-   Ehr#(2, Maybe#(dtyp)) val <- mkEhr(tagged Invalid);
+   Reg#(Maybe#(dtyp)) val <- mkConfigReg(tagged Invalid);
    
    method dtyp first();
-      if (val[0] matches tagged Valid.x)
+      if (val matches tagged Valid.x)
 	 return x;
       else
 	 return ?;
    endmethod
    
    method Bool canRead(ttyp t);
-      return nextTag[0] == t && isValid(val[0]);
+      return nextTag[0] == t && isValid(val);
    endmethod
    
    method Action deq();
       nextTag[0] <= nextTag[0] + 1;
-      val[0] <= tagged Invalid;
+      val <= tagged Invalid;
    endmethod
    //Order write operations _after_ read operations
    //to allow concurrent deq and enq
@@ -45,7 +46,7 @@ module mkOutputFIFOF(ttyp initT, OutputQ#(ttyp, dtyp) res) provisos
    endmethod
    
    method Action enq(dtyp d);
-      val[1] <= tagged Valid d;
+      val <= tagged Valid d;
    endmethod   
    
 endmodule

--- a/bscRuntime/memories/SpecialQueues.bsv
+++ b/bscRuntime/memories/SpecialQueues.bsv
@@ -1,0 +1,92 @@
+package SpecialQueues;
+
+import Ehr :: *;
+import FIFOF :: *;
+
+export OutputQ(..);
+
+export mkOutputFIFOF;
+export mkNBFIFOF;
+
+
+interface OutputQ#(type tag, type data);
+   method data first();
+   method Bool canRead(tag t);
+   method Action deq();
+   method Bool canWrite(tag t);
+   method Action enq(data d);
+endinterface
+
+module mkOutputFIFOF(ttyp initT, OutputQ#(ttyp, dtyp) res) provisos
+   (Bits#(ttyp, szttyp),Bits#(dtyp, szdtyp), Arith#(ttyp), Eq#(ttyp));
+
+   Ehr#(2, ttyp) nextTag <- mkEhr(initT);
+   Ehr#(2, Maybe#(dtyp)) val <- mkEhr(tagged Invalid);
+   
+   method dtyp first();
+      if (val[0] matches tagged Valid.x)
+	 return x;
+      else
+	 return ?;
+   endmethod
+   
+   method Bool canRead(ttyp t);
+      return nextTag[0] == t && isValid(val[0]);
+   endmethod
+   
+   method Action deq();
+      nextTag[0] <= nextTag[0] + 1;
+      val[0] <= tagged Invalid;
+   endmethod
+   //Order write operations _after_ read operations
+   //to allow concurrent deq and enq
+   method Bool canWrite(ttyp t);
+      return nextTag[1] == t;
+   endmethod
+   
+   method Action enq(dtyp d);
+      val[1] <= tagged Valid d;
+   endmethod   
+   
+endmodule
+
+module mkNBFIFOF(FIFOF#(dtyp)) provisos (Bits#(dtyp, szdtyp));
+   
+   FIFOF#(dtyp) f <- mkFIFOF();
+   //allow multiple writes in the same cycle
+   RWire#(dtyp) enq_data <- mkRWireSBR();
+   
+   (*fire_when_enabled*)
+   rule doEnq (enq_data.wget() matches tagged Valid.d);
+      f.enq(d);
+   endrule
+
+   //only allow the LAST enq each cycle to work, drop the others
+   method Action enq(dtyp a) if (f.notFull());
+      enq_data.wset(a);
+   endmethod
+   
+   method Action deq();
+      f.deq();
+   endmethod
+   
+   method dtyp first();
+      return f.first();
+   endmethod
+   
+   method Bool notFull();
+      return f.notFull();
+   endmethod
+   
+   method Bool notEmpty();
+      return f.notEmpty();
+   endmethod
+   
+   method Action clear();
+      f.clear();
+   endmethod
+   
+endmodule
+
+
+endpackage

--- a/bscRuntime/verilog/VerilogLibs.bsv
+++ b/bscRuntime/verilog/VerilogLibs.bsv
@@ -14,7 +14,7 @@ export mkForwardRenameRF;
 export mkCheckpointRF;
 export mkBypassRF;
 export mkCheckpointBypassRF;
-export mkNBFIFOF;
+
 export mkBHT;
 
 interface RenameRF#(type addr, type elem, type name);
@@ -299,44 +299,6 @@ module mkCheckpointBypassRF#(Integer regnum, Bool init, String fileInit)(Checkpo
 endmodule
    
    
-module mkNBFIFOF(FIFOF#(dtyp)) provisos (Bits#(dtyp, szdtyp));
-   
-   FIFOF#(dtyp) f <- mkFIFOF();
-   //allow multiple writes in the same cycle
-   RWire#(dtyp) enq_data <- mkRWireSBR();
-   
-   (*fire_when_enabled*)
-   rule doEnq (enq_data.wget() matches tagged Valid.d);
-      f.enq(d);
-   endrule
-
-   //only allow the LAST enq each cycle to work, drop the others
-   method Action enq(dtyp a) if (f.notFull());
-      enq_data.wset(a);
-   endmethod
-   
-   method Action deq();
-      f.deq();
-   endmethod
-   
-   method dtyp first();
-      return f.first();
-   endmethod
-   
-   method Bool notFull();
-      return f.notFull();
-   endmethod
-   
-   method Bool notEmpty();
-      return f.notEmpty();
-   endmethod
-   
-   method Action clear();
-      f.clear();
-   endmethod
-   
-endmodule
-
 interface BHT#(type addr);
    method addr req(addr pc, addr skip, addr take);
    method Action upd(addr pc, Bool take);

--- a/src/main/scala/pipedsl/codegen/bsv/BluespecGeneration.scala
+++ b/src/main/scala/pipedsl/codegen/bsv/BluespecGeneration.scala
@@ -19,6 +19,7 @@ object BluespecGeneration {
   private val memLib = "Memories"
   private val specLib = "Speculation"
   private val fifoLib = "FIFOF"
+  private val queueLib = "SpecialQueues"
   private val combLib = "RegFile"
   private val asyncLib = "BRAMCore"
   private val verilogLib = "VerilogLibs"
@@ -445,7 +446,7 @@ object BluespecGeneration {
     def getBSV: BProgram = {
       BProgram(name = mod.name.v.capitalize,
         topModule = topModule,
-        imports = List(BImport(fifoLib), BImport(lockLib), BImport(memLib),
+        imports = List(BImport(fifoLib), BImport(queueLib), BImport(lockLib), BImport(memLib),
           BImport(verilogLib), BImport(specLib), BImport(combLib), funcImport) ++
           bsvMods.values.map(bint => BImport(bint.name)).toList,
         exports = List(BExport(modInterfaceDef.typ.name, expFields = true), BExport(topModule.name, expFields = false)),

--- a/src/main/scala/pipedsl/codegen/bsv/BluespecGeneration.scala
+++ b/src/main/scala/pipedsl/codegen/bsv/BluespecGeneration.scala
@@ -376,16 +376,8 @@ object BluespecGeneration {
     //Registers for external communication
     private val busyReg = BVar("busyReg", bsInts.getRegType(BBool))
     private val threadIdVar = BVar(threadIdName, getThreadIdType)
-    private val outputStructHandle = BVar("handle", getThreadIdType)
-    private val outputStructData =  BVar("data", translator.toType(mod.ret.getOrElse(TVoid())))
-    private val outQueueStructName = "OutputQueueInfo"
-    private val outputQueueElem = if (mod.ret.isDefined) {
-      BStruct(outQueueStructName, List(outputStructHandle, outputStructData))
-    } else {
-      BStruct(outQueueStructName, List(outputStructHandle))
-    }
-    private val outputQueueStruct = BStructDef(outputQueueElem, List("Bits", "Eq"))
-    private val outputQueue = BVar("outputQueue", bsInts.getFifoType(outputQueueElem))
+    private val outputData =  BVar("data", translator.toType(mod.ret.getOrElse(TVoid())))
+    private val outputQueue = BVar("outputQueue", bsInts.getOutputQType(threadIdVar.typ, outputData.typ))
 
     //Data types for passing between stages
     private val edgeStructInfo = getEdgeStructInfo(otherStages, addTId = true, addSpecId = mod.maybeSpec)
@@ -450,7 +442,7 @@ object BluespecGeneration {
           BImport(verilogLib), BImport(specLib), BImport(combLib), funcImport) ++
           bsvMods.values.map(bint => BImport(bint.name)).toList,
         exports = List(BExport(modInterfaceDef.typ.name, expFields = true), BExport(topModule.name, expFields = false)),
-        structs = firstStageStruct +: edgeStructInfo.values.toList :+ outputQueueStruct,
+        structs = firstStageStruct +: edgeStructInfo.values.toList,
         interfaces = List(modInterfaceDef),
         modules = List())
     }
@@ -671,7 +663,7 @@ object BluespecGeneration {
         //these are just to find EMemAccesses that are also atomic
         case CAssign(_, rhs) => l ++ getBlockConds(rhs)
         case CRecv(_, rhs) => l ++ getBlockConds(rhs)
-        case COutput(_) => if (mod.isRecursive) l :+ busyReg else l
+        case COutput(_) => l :+ bsInts.getOutCanWrite(outputQueue, translator.toBSVVar(threadIdVar))
           //Execute ONLY if check(specid) == Valid(True) && isValid(specid)
           // fromMaybe(False, check(specId)) <=>  check(specid) == Valid(True)
         case CCheckSpec(isBlocking) if isBlocking => l ++ List(
@@ -828,7 +820,7 @@ object BluespecGeneration {
           //if value is expected to come in on that edge, use that
           //else we're not going to use the value later, send a dont care
           val edgeValue = if (edge.values.contains(v)) {
-            val paramExpr = bsInts.getFifoPeek(edgeParams(edge))
+            val paramExpr = bsInts.getFifoFirst(edgeParams(edge))
             BStructAccess(paramExpr, BVar(v.v, translator.toType(v.typ.get)))
           } else {
             BDontCare
@@ -876,7 +868,7 @@ object BluespecGeneration {
       //Instantiate the registers that describes when the module is busy/ready for inputs
       //And how it returns outputs
       val busyInst = BModInst(busyReg, bsInts.getReg(BBoolLit(false)))
-      val outputInst = BModInst(outputQueue, bsInts.getFifo)
+      val outputInst = BModInst(outputQueue, bsInts.getOutputQ(BZero))
       val threadInst = BModInst(BVar(threadIdName, bsInts.getRegType(getThreadIdType)),
         bsInts.getReg(BZero))
       //Instantiate the speculation table if the module is speculative
@@ -903,7 +895,7 @@ object BluespecGeneration {
       methods = methods :+ reqMethodDef
       val respMethodDef = BMethodDef(
         sig = bsInts.getResponseMethod(modInterfaceDef),
-        cond = None, //implicit condition of outputqueue being non empty means we don't need this
+        cond = None,
         body = List(
           BExprStmt(bsInts.getFifoDeq(outputQueue))
         )
@@ -914,9 +906,8 @@ object BluespecGeneration {
           sig = bsInts.getPeekMethod(modInterfaceDef),
           cond = None, //implicit condition of outputqueue being non empty means we don't need this
           body = List(
-            BReturnStmt(
-              BStructAccess(bsInts.getFifoPeek(outputQueue), outputStructData)
-            ))
+            BReturnStmt(bsInts.getFifoFirst(outputQueue))
+          )
         ))
       } else { None }
       if (peekMethodDef.isDefined) { methods = methods :+ peekMethodDef.get}
@@ -925,10 +916,9 @@ object BluespecGeneration {
         sig = handleMethodSig,
         cond = None,
         body = List(
-          BReturnStmt(BBOp("==",
-            handleMethodSig.params.head,
-            BStructAccess(bsInts.getFifoPeek(outputQueue), outputStructHandle)
-          ))
+          BReturnStmt(
+            bsInts.getOutCanRead(outputQueue, handleMethodSig.params.head)
+          )
         )
       )
       methods = methods :+ handleMethodCheck
@@ -1188,19 +1178,16 @@ object BluespecGeneration {
       case IRecv(_, sender, _) =>
         Some(BExprStmt(bsInts.getModResponse(modParams(sender))))
       case COutput(exp) =>
-        val outstruct = if (mod.ret.isDefined) {
-          BStructLit(outputQueueElem,
-            Map(outputStructData -> translator.toExpr(exp),
-              outputStructHandle -> translator.toBSVVar(threadIdVar))
-          )
+        val outval = if (mod.ret.isDefined) {
+          translator.toExpr(exp)
         } else {
-          BStructLit(outputQueueElem, Map(outputStructHandle -> translator.toBSVVar(threadIdVar)))
+          BDontCare
         }
         Some(BStmtSeq(List(
           //we're done processing the current request
           if (mod.isRecursive) BModAssign(busyReg, BBoolLit(false)) else BEmpty,
           //place the result in the output queue
-          BExprStmt(bsInts.getFifoEnq(outputQueue, outstruct))
+          BExprStmt(bsInts.getFifoEnq(outputQueue, outval))
         )))
       case cl@IReserveLock(outHandle, mem) =>
         val methodInfo = LockImplementation.getReserveInfo(cl)

--- a/src/main/scala/pipedsl/codegen/bsv/BluespecInterfaces.scala
+++ b/src/main/scala/pipedsl/codegen/bsv/BluespecInterfaces.scala
@@ -270,6 +270,7 @@ class BluespecInterfaces() {
   }
   def getFifo: BModule = BModule(fifoModuleName, List())
   def getNBFifo: BModule = BModule(fifoNBModuleName, List())
+  def getBypassFifo: BModule = BModule("mkBypassFIFOF", List())
   def getOutputQ(init: BExpr): BModule = BModule("mkOutputFIFOF", List(init))
   def getFifoDeq(f: BVar): BMethodInvoke = {
     BMethodInvoke(f, fifoDequeuMethodName, List())

--- a/src/main/scala/pipedsl/codegen/bsv/BluespecInterfaces.scala
+++ b/src/main/scala/pipedsl/codegen/bsv/BluespecInterfaces.scala
@@ -265,17 +265,26 @@ class BluespecInterfaces() {
   def getFifoType(typ: BSVType): BInterface = {
     BInterface(fifoType, List(BVar("elemtyp", typ)))
   }
-
+  def getOutputQType(ttyp: BSVType, dtyp: BSVType): BInterface = {
+    BInterface("OutputQ", List(BVar("tagtyp", ttyp), BVar("datatyp", dtyp)));
+  }
   def getFifo: BModule = BModule(fifoModuleName, List())
   def getNBFifo: BModule = BModule(fifoNBModuleName, List())
+  def getOutputQ(init: BExpr): BModule = BModule("mkOutputFIFOF", List(init))
   def getFifoDeq(f: BVar): BMethodInvoke = {
     BMethodInvoke(f, fifoDequeuMethodName, List())
   }
   def getFifoEnq(f: BVar, data: BExpr): BMethodInvoke = {
     BMethodInvoke(f, fifoEnqueueMethodName, List(data))
   }
-  def getFifoPeek(f: BVar): BMethodInvoke = {
+  def getFifoFirst(f: BVar): BMethodInvoke = {
     BMethodInvoke(f, fifoFirstMethodName, List())
+  }
+  def getOutCanWrite(q: BVar, tag: BExpr): BMethodInvoke = {
+    BMethodInvoke(q, "canWrite", List(tag));
+  }
+  def getOutCanRead(q: BVar, tag: BExpr): BMethodInvoke = {
+    BMethodInvoke(q, "canRead", List(tag));
   }
 
   private val specHandleName = "SpecId"


### PR DESCRIPTION
This implements the following changes:
 - Linear pipelines (i.e. those that don't loop) now use the BypassQueue for their inputs by default, so calling them doesn't induce a 1 cycle delay.
 - The response queues for pipelines enforce that responses are available only in the original request order (i.e. blocking queues). We can reimplement the non-blocking queue functionality in the future.